### PR TITLE
Feature/Add support for RGB and named color formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ pyzotero/
 pywintypes.pyi
 test.py
 main.py
+
+venv/
+env/
+.env/
+.venv/
+ENV/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install noterools
 2. 创建一个 Python 脚本并运行。以下是一个简单的示例
 
 ```python
-from noterools import Word, add_cross_ref_style_hook
+from noterools import Word, add_cross_ref_style_hook, add_url_hyperlink_hook
 from noterools._entry import add_citation_cross_ref_hook
 
 if __name__ == '__main__':
@@ -55,6 +55,10 @@ if __name__ == '__main__':
         # 16711680: 蓝色
         # 更多颜色请参考 Word 中的颜色枚举类型: https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor
         # add_citation_cross_ref_hook(word, is_numbered=False, color=0)
+        # 或者使用 RGB 值
+        # add_cross_ref_style_hook(word, is_numbered=False, color="0, 0, 255")
+        # 或者设为 Microsoft Word 中的“自动”，该颜色在浅色模式下为黑色，深色模式下为白色
+        # add_cross_ref_style_hook(word, is_numbered=False, color="word_auto")
 
         # set_container_title_italic 用于控制是否修正参考文献表中没有正确设置为斜体的名称
         # 你可以通过将其设置为 False 来关闭这项功能
@@ -79,13 +83,13 @@ if __name__ == '__main__':
         # 将英文标题改为仅句首单词的首字母大写
         # add_format_title_hook(word, lower_all_words=True)
 
-    # 改为仅句首单词的首字母大写时，你可以给出一个专有名词列表，noterools 会检测其中的专有名词，防止这些名词被错误设置为小写
-    # word_list = ["UNet", "US", "China", "WRF"]
-    # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
+        # 改为仅句首单词的首字母大写时，你可以给出一个专有名词列表，noterools 会检测其中的专有名词，防止这些名词被错误设置为小写
+        # word_list = ["UNet", "US", "China", "WRF"]
+        # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
 
-    # 为参考文献目录表中出现的网址添加超链接
-    # add_url_hyperlink_hook(word)
+        # 为参考文献目录表中出现的网址添加超链接
+        # add_url_hyperlink_hook(word)
 
-    # 自定义超链接的颜色以及是否添加下划线 (参数可选)
-    # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
+        # 自定义超链接的颜色以及是否添加下划线 (参数可选)
+        # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,7 +37,7 @@ pip install noterools
 2. Create a Python script and run it. Here is a simple example.
 
 ```python
-from noterools import Word, add_cross_ref_style_hook
+from noterools import Word, add_cross_ref_style_hook, add_url_hyperlink_hook
 from noterools._entry import add_citation_cross_ref_hook
 
 if __name__ == '__main__':
@@ -57,6 +57,10 @@ if __name__ == '__main__':
         # 16711680: Blues
         # For more colors, please see: https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor
         # add_citation_cross_ref_hook(word, is_numbered=False, color=0)
+        # Or input RGB value instead
+        # add_cross_ref_style_hook(word, is_numbered=False, color="0, 0, 255")
+        # Or change to "Automatic" in Microsoft Word
+        # add_cross_ref_style_hook(word, is_numbered=False, color="word_auto")
 
         # set_container_title_italic is used to control whether to correct names in the bibliography that are not properly italicized.
         # You can disable this feature by setting it to False.
@@ -81,13 +85,13 @@ if __name__ == '__main__':
         # Change English articles' title format to Sentence Case.
         # add_format_title_hook(word, lower_all_words=True)
 
-    # You can give a list contains proper noun when change format to Sentence Case.
-    # word_list = ["UNet", "US", "China", "WRF"]
-    # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
+        # You can give a list contains proper noun when change format to Sentence Case.
+        # word_list = ["UNet", "US", "China", "WRF"]
+        # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
 
-    # Add hyperlinks to URLs in bibliography
-    # add_url_hyperlink_hook(word)
+        # Add hyperlinks to URLs in bibliography
+        # add_url_hyperlink_hook(word)
 
-    # And customize URL appearance (parameters are optional)
-    # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
+        # And customize URL appearance (parameters are optional)
+        # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
 ```

--- a/noterools/_entry.py
+++ b/noterools/_entry.py
@@ -3,7 +3,7 @@ from .citation import add_citation_hyperlink_hook
 from .word import Word
 
 
-def add_citation_cross_ref_hook(word: Word, is_numbered=False, color: int = 16711680, no_under_line=True, set_container_title_italic=True):
+def add_citation_cross_ref_hook(word: Word, is_numbered=False, color=16711680, no_under_line=True, set_container_title_italic=True):
     """
     Register hooks to add hyperlinks from citations to bibliographies.
 
@@ -11,9 +11,12 @@ def add_citation_cross_ref_hook(word: Word, is_numbered=False, color: int = 1671
     :type word: Word
     :param is_numbered: If your citation is numbered. Defaults to False.
     :type is_numbered: bool
-    :param color: Set font color. Defaults to ``blue (16711680)``. You can look up the value at `VBA Documentation
-                  <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to blue (16711680).
+                 You can look up the values at `VBA Documentation
+                 <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to True.
     :type no_under_line: bool
     :param set_container_title_italic: If italicize the container title and publisher name in bibliography. Defaults to True.

--- a/noterools/bibliography.py
+++ b/noterools/bibliography.py
@@ -7,7 +7,7 @@ from rich.progress import Progress
 from .csl import GetCSLJsonHook, add_get_csl_json_hook
 from .error import AddHyperlinkError, HookNotRegisteredError, ParamsError
 from .hook import ExtensionHookBase, HOOKTYPE, HookBase
-from .utils import logger, find_urls
+from .utils import logger, find_urls, parse_color
 from .word import Word
 from .zotero import zotero_check_initialized, zotero_query_pages
 
@@ -626,17 +626,19 @@ class BibURLHyperlinkHook(ExtensionHookBase):
     This extension hook adds hyperlinks to URLs in your bibliography.
     """
     
-    def __init__(self, color: int = None, no_under_line=False):
+    def __init__(self, color=None, no_under_line=False):
         """
         Initialize the URL hyperlink hook.
 
-        :param color: Set font color for URLs. Defaults to None (keep original color).
-        :type color: int
+        :param color: Set font color for URLs. Accepts integer decimal value (e.g., 16711680 for blue), 
+                     RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                     Defaults to None (keep original color).
+        :type color: Union[int, str, None]
         :param no_under_line: If remove the underline of hyperlinks. Defaults to False.
         :type no_under_line: bool
         """
         super().__init__(name="BibURLHyperlinkHook")
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.no_under_line = no_under_line
 
     def on_iterate(self, word: Word, word_range):
@@ -681,20 +683,22 @@ class BibURLHyperlinkHook(ExtensionHookBase):
                 logger.warning(f"Failed to add hyperlink for URL: {url}")
 
 
-def add_url_hyperlink_hook(word: Word, color: int = None, no_under_line=False) -> BibURLHyperlinkHook:
+def add_url_hyperlink_hook(word: Word, color=None, no_under_line=False) -> BibURLHyperlinkHook:
     """
     Register ``BibURLHyperlinkHook`` to add hyperlinks to URLs in bibliography.
 
     :param word: ``noterools.word.Word`` object.
     :type word: Word
-    :param color: Set font color for URLs. Defaults to None (keep original color).
-    :type color: int
+    :param color: Set font color for URLs. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to None (keep original color).
+    :type color: Union[int, str, None]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to False.
     :type no_under_line: bool
     :return: ``BibURLHyperlinkHook`` instance.
     :rtype: BibURLHyperlinkHook
     """
-    add_get_csl_json_hook(word)  # In case it's needed for future functionality
+    add_get_csl_json_hook(word)
     url_hyperlink_hook = BibURLHyperlinkHook(color, no_under_line)
     bib_loop_hook = add_bib_loop_hook(word)
     bib_loop_hook.set_hook(url_hyperlink_hook)

--- a/noterools/citation.py
+++ b/noterools/citation.py
@@ -4,7 +4,7 @@ from os.path import basename
 from .csl import CSLJson
 from .error import AddHyperlinkError
 from .hook import HookBase
-from .utils import get_year_list, logger, replace_invalid_char
+from .utils import get_year_list, logger, replace_invalid_char, parse_color
 from .word import Word
 
 
@@ -13,10 +13,10 @@ class CitationHyperlinkHook(HookBase):
     Hook to add hyperlinks to citations.
     """
 
-    def __init__(self, is_numbered=False, color: int = None, no_under_line=True):
+    def __init__(self, is_numbered=False, color=None, no_under_line=True):
         super().__init__("CitationHyperlinkHook")
         self.is_numbered = is_numbered
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.no_under_line = no_under_line
 
     def on_iterate(self, word_obj: Word, field):
@@ -120,7 +120,7 @@ class CitationHyperlinkHook(HookBase):
             color_range.MoveEnd(Unit=1, Count=1)
 
 
-def add_citation_hyperlink_hook(word: Word, is_numbered=False, color: int = None, no_under_line=True) -> CitationHyperlinkHook:
+def add_citation_hyperlink_hook(word: Word, is_numbered=False, color=None, no_under_line=True) -> CitationHyperlinkHook:
     """
     Register ``CitationHyperlinkHook``.
 
@@ -128,8 +128,10 @@ def add_citation_hyperlink_hook(word: Word, is_numbered=False, color: int = None
     :type word: Word
     :param is_numbered: If your citation is numbered. Defaults to False.
     :type is_numbered: bool
-    :param color: Set font color. You can look up the value at `VBA Documentation <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 You can look up the values at `VBA Documentation <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str, None]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to True.
     :type no_under_line: bool
     :return: ``CitationHyperlinkHook`` instance.

--- a/noterools/colors.py
+++ b/noterools/colors.py
@@ -1,5 +1,5 @@
 from .hook import HookBase
-from .utils import logger
+from .utils import logger, parse_color
 from .word import Word
 
 
@@ -7,12 +7,11 @@ class CrossRefStyleHook(HookBase):
     """
     Set style of cross-reference.
     """
-    def __init__(self, color: int = None, bold=False, key_word: list[str] = None):
+    def __init__(self, color=None, bold=False, key_word: list[str] = None):
         super().__init__(f"CrossRefStyleHook")
 
         if key_word is None:
             self.key_word = [""]
-
         else:
             if len(key_word) > 1 and "" in key_word:
                 logger.warning("Found empty string in your keyword. It can cause noterools to change all of your cross references")
@@ -21,7 +20,7 @@ class CrossRefStyleHook(HookBase):
 
             self.key_word = key_word
 
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.bold = bold
 
     def on_iterate(self, word, field):
@@ -55,22 +54,25 @@ class CrossRefStyleHook(HookBase):
         field.Update()
 
 
-def add_cross_ref_style_hook(word: Word, color: int = 16711680, bold=False, key_word: list[str] = None) -> CrossRefStyleHook:
+def add_cross_ref_style_hook(word: Word, color=16711680, bold=False, key_word: list[str] = None) -> CrossRefStyleHook:
     """
     Set font style of the cross-reference.
 
     :param word: ``noterools.word.Word`` object.
     :type word: Word
-    :param color: Set font color. Defaults to ``blue (16711680)``. You can look up the value at `VBA Documentation
-                  <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to blue (16711680).
+                 You can look up the values at `VBA Documentation
+                 <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str]
     :param bold: If you make font bold. Defaults to False.
     :type bold: bool
-    :param key_word: A key word list. noterools only change the cross-ref's style which contains the key word you specify, for example, ``["Fig.", "Tab."]``.
-                     noterools will change all cross-refs style if ``ket_word == None``.
+    :param key_word: A key word list. noterools only change the cross-ref's style which contains the key word you specify, 
+                     for example, ``["Fig.", "Tab."]``. noterools will change all cross-refs style if ``key_word == None``.
     :type key_word: list
-    :return:
-    :rtype:
+    :return: The hook instance
+    :rtype: CrossRefStyleHook
     """
     if key_word is None:
         logger.warning("Set style for all cross references because `key_word` is None")

--- a/noterools/utils.py
+++ b/noterools/utils.py
@@ -76,4 +76,49 @@ def find_urls(text: str) -> list[tuple[int, int, str]]:
     return urls
 
 
-__all__ = ["logger", "replace_invalid_char", "get_year_list", "find_urls"]
+def parse_color(color_input):
+    """
+    Parse different color input formats and return the Word VBA Decimal color value.
+    
+    Accepts:
+    - Integer decimal value (e.g., 16711680 for blue)
+    - RGB string (e.g., "255, 0, 0" for red)
+    - Named color constant (e.g., "word_auto" for automatic color)
+    
+    :param color_input: Color in various formats
+    :type color_input: Union[int, str, None]
+    :return: Word VBA Decimal color value
+    :rtype: int or None
+    """
+    # If None, return None (keep default behavior)
+    if color_input is None:
+        return None
+        
+    # If already an integer, assume it's already a valid Decimal color value
+    if isinstance(color_input, int):
+        return color_input
+        
+    # If string, check for different formats
+    if isinstance(color_input, str):
+        # Check for named constants
+        if color_input.lower() == "word_auto":
+            return -16777216  # wdColorAutomatic
+            
+        # Check for RGB format (e.g., "255, 0, 0")
+        try:
+            # Split by comma and strip whitespace
+            rgb_values = [int(x.strip()) for x in color_input.split(",")]
+            
+            # If we have 3 values between 0-255, treat as RGB
+            if len(rgb_values) == 3 and all(0 <= x <= 255 for x in rgb_values):
+                r, g, b = rgb_values
+                # Convert to Word Decimal format: B × 2^16 + G × 2^8 + R
+                return (b << 16) + (g << 8) + r
+        except (ValueError, TypeError):
+            pass
+            
+    # If we reach here, the input format is invalid
+    raise ValueError(f"Invalid color format: {color_input}. Use an integer Decimal value, RGB string (e.g., '255, 0, 0'), or 'word_auto'.")
+
+
+__all__ = ["logger", "replace_invalid_char", "get_year_list", "find_urls", "parse_color"]


### PR DESCRIPTION
## 功能描述

此 PR 添加了对多种颜色输入格式的支持，使 noterools 更加用户友好：

- 保留对现有十进制值的支持 (例如 `16711680` 代表蓝色)
- 添加对 RGB 字符串的支持 (例如 `"33, 150, 209"` 代表蓝色)
- 定义了一个常量`"word_auto"`， 代表自动颜色

## 实现方式

- 在 `utils.py` 中添加了 `parse_color()` 工具函数
- 更新了所有接受颜色参数的函数，使其能处理多种输入格式
- 更新了函数文档，说明支持的颜色输入格式

## 测试

已对以下颜色输入格式进行了测试：
- 十进制值 (例如 16711680)
- RGB 字符串 (例如 "255, 0, 0")
- "word_auto"

测试了 Zotero 中的 Cite Them Right 12th edition-Harvard (no "et al.") CSL，对文内引用和参考文献列表中的超链接的颜色做了更改。上述三种格式都能正确转换为 Word VBA 所需的十进制值。

## Functional description

This PR adds support for multiple colour input formats to make noterools more user-friendly:

- Retains support for existing decimal values (e.g. `16711680` for blue).
- Added support for RGB strings (e.g. `"33, 150, 209"` for blue).
- Defined a constant `"word_auto"` for automatic colours

## Implementation

- Added `parse_colour()` utility function to `utils.py`.
- Updated all functions that take colour arguments to handle multiple input formats.
- Updated function documentation to include supported colour input formats.

## Testing

The following colour input formats have been tested:
- Decimal values (e.g. 16711680)
- RGB string (e.g. "255, 0, 0")
- "word_auto"

Cite Them Right 12th edition-Harvard (no "et al.") CSL in Zotero was tested, with changes made to the colours of in-text citations and hyperlinks in the reference list. All three of these formats converted correctly to the decimal values required by Word VBA.