### PR TITLE
Feature/Full citation hyperlink for (Author, Date)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ pyzotero/
 pywintypes.pyi
 test.py
 main.py
+
+venv/
+env/
+.env/
+.venv/
+ENV/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install noterools
 2. 创建一个 Python 脚本并运行。以下是一个简单的示例
 
 ```python
-from noterools import Word, add_cross_ref_style_hook
+from noterools import Word, add_cross_ref_style_hook, add_url_hyperlink_hook
 from noterools._entry import add_citation_cross_ref_hook
 
 if __name__ == '__main__':
@@ -55,6 +55,10 @@ if __name__ == '__main__':
         # 16711680: 蓝色
         # 更多颜色请参考 Word 中的颜色枚举类型: https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor
         # add_citation_cross_ref_hook(word, is_numbered=False, color=0)
+        # 或者使用 RGB 值
+        # add_cross_ref_style_hook(word, is_numbered=False, color="0, 0, 255")
+        # 或者设为 Microsoft Word 中的“自动”，该颜色在浅色模式下为黑色，深色模式下为白色
+        # add_cross_ref_style_hook(word, is_numbered=False, color="word_auto")
 
         # set_container_title_italic 用于控制是否修正参考文献表中没有正确设置为斜体的名称
         # 你可以通过将其设置为 False 来关闭这项功能
@@ -79,13 +83,13 @@ if __name__ == '__main__':
         # 将英文标题改为仅句首单词的首字母大写
         # add_format_title_hook(word, lower_all_words=True)
 
-    # 改为仅句首单词的首字母大写时，你可以给出一个专有名词列表，noterools 会检测其中的专有名词，防止这些名词被错误设置为小写
-    # word_list = ["UNet", "US", "China", "WRF"]
-    # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
+        # 改为仅句首单词的首字母大写时，你可以给出一个专有名词列表，noterools 会检测其中的专有名词，防止这些名词被错误设置为小写
+        # word_list = ["UNet", "US", "China", "WRF"]
+        # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
 
-    # 为参考文献目录表中出现的网址添加超链接
-    # add_url_hyperlink_hook(word)
+        # 为参考文献目录表中出现的网址添加超链接
+        # add_url_hyperlink_hook(word)
 
-    # 自定义超链接的颜色以及是否添加下划线 (参数可选)
-    # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
+        # 自定义超链接的颜色以及是否添加下划线 (参数可选)
+        # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ if __name__ == '__main__':
 
         # 为 (作者, 年份) 引用格式添加超链接，设置引用为蓝色。
         # 默认会将参考文献表中没有被正确设置为斜体的刊物名称或出版商设置为斜体
-        # add_citation_cross_ref_hook(word, is_numbered=False)
+        # 默认情况下，只有年份部分会添加超链接，设置 full_citation_hyperlink=True 可以让整个引用(作者+年份)都添加超链接
+        # add_citation_cross_ref_hook(word, is_numbered=False, full_citation_hyperlink=True)
 
         # 通过设置 color 的值，可以设置整个引用的颜色(不包含括号)
         # 0: 黑色

--- a/README_EN.md
+++ b/README_EN.md
@@ -50,7 +50,8 @@ if __name__ == '__main__':
 
         # Add hyperlinks to (Author, Year) citation format, set the citation font color to blue.
         # By default, container titles or publishers in the bibliography that are not correctly italicized will be set to italics.
-        # add_citation_cross_ref_hook(word, is_numbered=False)
+        # By default, only the year portion is hyperlinked. Set full_citation_hyperlink=True to make the entire citation (author+year) hyperlinked
+        # add_citation_cross_ref_hook(word, is_numbered=False, full_citation_hyperlink=True)
 
         # By setting the value of color, you can change the color of the entire citation (excluding the parentheses).
         # 0: Black

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,7 +37,7 @@ pip install noterools
 2. Create a Python script and run it. Here is a simple example.
 
 ```python
-from noterools import Word, add_cross_ref_style_hook
+from noterools import Word, add_cross_ref_style_hook, add_url_hyperlink_hook
 from noterools._entry import add_citation_cross_ref_hook
 
 if __name__ == '__main__':
@@ -57,6 +57,10 @@ if __name__ == '__main__':
         # 16711680: Blues
         # For more colors, please see: https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor
         # add_citation_cross_ref_hook(word, is_numbered=False, color=0)
+        # Or input RGB value instead
+        # add_cross_ref_style_hook(word, is_numbered=False, color="0, 0, 255")
+        # Or change to "Automatic" in Microsoft Word
+        # add_cross_ref_style_hook(word, is_numbered=False, color="word_auto")
 
         # set_container_title_italic is used to control whether to correct names in the bibliography that are not properly italicized.
         # You can disable this feature by setting it to False.
@@ -81,13 +85,13 @@ if __name__ == '__main__':
         # Change English articles' title format to Sentence Case.
         # add_format_title_hook(word, lower_all_words=True)
 
-    # You can give a list contains proper noun when change format to Sentence Case.
-    # word_list = ["UNet", "US", "China", "WRF"]
-    # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
+        # You can give a list contains proper noun when change format to Sentence Case.
+        # word_list = ["UNet", "US", "China", "WRF"]
+        # add_format_title_hook(word, lower_all_words=True, word_list=word_list)
 
-    # Add hyperlinks to URLs in bibliography
-    # add_url_hyperlink_hook(word)
+        # Add hyperlinks to URLs in bibliography
+        # add_url_hyperlink_hook(word)
 
-    # And customize URL appearance (parameters are optional)
-    # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
+        # And customize URL appearance (parameters are optional)
+        # add_url_hyperlink_hook(word, color=16711680, no_under_line=False)
 ```

--- a/noterools/_entry.py
+++ b/noterools/_entry.py
@@ -3,7 +3,7 @@ from .citation import add_citation_hyperlink_hook
 from .word import Word
 
 
-def add_citation_cross_ref_hook(word: Word, is_numbered=False, color=16711680, no_under_line=True, set_container_title_italic=True):
+def add_citation_cross_ref_hook(word: Word, is_numbered=False, color=16711680, no_under_line=True, set_container_title_italic=True, full_citation_hyperlink=False):
     """
     Register hooks to add hyperlinks from citations to bibliographies.
 
@@ -21,8 +21,10 @@ def add_citation_cross_ref_hook(word: Word, is_numbered=False, color=16711680, n
     :type no_under_line: bool
     :param set_container_title_italic: If italicize the container title and publisher name in bibliography. Defaults to True.
     :type set_container_title_italic: bool
+    :param full_citation_hyperlink: If True, the entire citation (author and year) will be hyperlinked for the first reference in multiple citations. For subsequent references in the same citation block, only the year will be hyperlinked due to technical limitations. Defaults to False (only year is hyperlinked).
+    :type full_citation_hyperlink: bool
     """
-    add_citation_hyperlink_hook(word, is_numbered, color, no_under_line)
+    add_citation_hyperlink_hook(word, is_numbered, color, no_under_line, full_citation_hyperlink)
     add_bib_bookmark_hook(word, is_numbered, set_container_title_italic)
 
 

--- a/noterools/_entry.py
+++ b/noterools/_entry.py
@@ -3,7 +3,7 @@ from .citation import add_citation_hyperlink_hook
 from .word import Word
 
 
-def add_citation_cross_ref_hook(word: Word, is_numbered=False, color: int = 16711680, no_under_line=True, set_container_title_italic=True):
+def add_citation_cross_ref_hook(word: Word, is_numbered=False, color=16711680, no_under_line=True, set_container_title_italic=True):
     """
     Register hooks to add hyperlinks from citations to bibliographies.
 
@@ -11,9 +11,12 @@ def add_citation_cross_ref_hook(word: Word, is_numbered=False, color: int = 1671
     :type word: Word
     :param is_numbered: If your citation is numbered. Defaults to False.
     :type is_numbered: bool
-    :param color: Set font color. Defaults to ``blue (16711680)``. You can look up the value at `VBA Documentation
-                  <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to blue (16711680).
+                 You can look up the values at `VBA Documentation
+                 <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to True.
     :type no_under_line: bool
     :param set_container_title_italic: If italicize the container title and publisher name in bibliography. Defaults to True.

--- a/noterools/bibliography.py
+++ b/noterools/bibliography.py
@@ -7,7 +7,7 @@ from rich.progress import Progress
 from .csl import GetCSLJsonHook, add_get_csl_json_hook
 from .error import AddHyperlinkError, HookNotRegisteredError, ParamsError
 from .hook import ExtensionHookBase, HOOKTYPE, HookBase
-from .utils import logger, find_urls
+from .utils import logger, find_urls, parse_color
 from .word import Word
 from .zotero import zotero_check_initialized, zotero_query_pages
 
@@ -626,17 +626,19 @@ class BibURLHyperlinkHook(ExtensionHookBase):
     This extension hook adds hyperlinks to URLs in your bibliography.
     """
     
-    def __init__(self, color: int = None, no_under_line=False):
+    def __init__(self, color=None, no_under_line=False):
         """
         Initialize the URL hyperlink hook.
 
-        :param color: Set font color for URLs. Defaults to None (keep original color).
-        :type color: int
+        :param color: Set font color for URLs. Accepts integer decimal value (e.g., 16711680 for blue), 
+                     RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                     Defaults to None (keep original color).
+        :type color: Union[int, str, None]
         :param no_under_line: If remove the underline of hyperlinks. Defaults to False.
         :type no_under_line: bool
         """
         super().__init__(name="BibURLHyperlinkHook")
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.no_under_line = no_under_line
 
     def on_iterate(self, word: Word, word_range):
@@ -681,20 +683,22 @@ class BibURLHyperlinkHook(ExtensionHookBase):
                 logger.warning(f"Failed to add hyperlink for URL: {url}")
 
 
-def add_url_hyperlink_hook(word: Word, color: int = None, no_under_line=False) -> BibURLHyperlinkHook:
+def add_url_hyperlink_hook(word: Word, color=None, no_under_line=False) -> BibURLHyperlinkHook:
     """
     Register ``BibURLHyperlinkHook`` to add hyperlinks to URLs in bibliography.
 
     :param word: ``noterools.word.Word`` object.
     :type word: Word
-    :param color: Set font color for URLs. Defaults to None (keep original color).
-    :type color: int
+    :param color: Set font color for URLs. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to None (keep original color).
+    :type color: Union[int, str, None]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to False.
     :type no_under_line: bool
     :return: ``BibURLHyperlinkHook`` instance.
     :rtype: BibURLHyperlinkHook
     """
-    add_get_csl_json_hook(word)  # In case it's needed for future functionality
+    add_get_csl_json_hook(word)
     url_hyperlink_hook = BibURLHyperlinkHook(color, no_under_line)
     bib_loop_hook = add_bib_loop_hook(word)
     bib_loop_hook.set_hook(url_hyperlink_hook)

--- a/noterools/citation.py
+++ b/noterools/citation.py
@@ -4,7 +4,7 @@ from os.path import basename
 from .csl import CSLJson
 from .error import AddHyperlinkError
 from .hook import HookBase
-from .utils import get_year_list, logger, replace_invalid_char
+from .utils import get_year_list, logger, replace_invalid_char, parse_color
 from .word import Word
 
 
@@ -13,10 +13,10 @@ class CitationHyperlinkHook(HookBase):
     Hook to add hyperlinks to citations.
     """
 
-    def __init__(self, is_numbered=False, color: int = None, no_under_line=True):
+    def __init__(self, is_numbered=False, color=None, no_under_line=True):
         super().__init__("CitationHyperlinkHook")
         self.is_numbered = is_numbered
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.no_under_line = no_under_line
 
     def on_iterate(self, word_obj: Word, field):
@@ -120,7 +120,7 @@ class CitationHyperlinkHook(HookBase):
             color_range.MoveEnd(Unit=1, Count=1)
 
 
-def add_citation_hyperlink_hook(word: Word, is_numbered=False, color: int = None, no_under_line=True) -> CitationHyperlinkHook:
+def add_citation_hyperlink_hook(word: Word, is_numbered=False, color=None, no_under_line=True) -> CitationHyperlinkHook:
     """
     Register ``CitationHyperlinkHook``.
 
@@ -128,8 +128,10 @@ def add_citation_hyperlink_hook(word: Word, is_numbered=False, color: int = None
     :type word: Word
     :param is_numbered: If your citation is numbered. Defaults to False.
     :type is_numbered: bool
-    :param color: Set font color. You can look up the value at `VBA Documentation <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 You can look up the values at `VBA Documentation <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str, None]
     :param no_under_line: If remove the underline of hyperlinks. Defaults to True.
     :type no_under_line: bool
     :return: ``CitationHyperlinkHook`` instance.

--- a/noterools/citation.py
+++ b/noterools/citation.py
@@ -70,7 +70,8 @@ class CitationHyperlinkHook(HookBase):
                         oRange.MoveStart(Unit=1, Count=len(authors_text))
                         oRange.MoveEnd(Unit=1, Count=-len(citation_text_left))
                     else:
-                        # "Author, Date" will have hyperlink
+                        # "Author, Date" will have hyperlink, but we have to exclude brackets
+                        oRange.MoveStart(Unit=1, Count=1) # Move after the left bracket
                         oRange.MoveEnd(Unit=1, Count=-len(citation_text_left))  
                     is_first = False
                 else:

--- a/noterools/colors.py
+++ b/noterools/colors.py
@@ -1,5 +1,5 @@
 from .hook import HookBase
-from .utils import logger
+from .utils import logger, parse_color
 from .word import Word
 
 
@@ -7,12 +7,11 @@ class CrossRefStyleHook(HookBase):
     """
     Set style of cross-reference.
     """
-    def __init__(self, color: int = None, bold=False, key_word: list[str] = None):
+    def __init__(self, color=None, bold=False, key_word: list[str] = None):
         super().__init__(f"CrossRefStyleHook")
 
         if key_word is None:
             self.key_word = [""]
-
         else:
             if len(key_word) > 1 and "" in key_word:
                 logger.warning("Found empty string in your keyword. It can cause noterools to change all of your cross references")
@@ -21,7 +20,7 @@ class CrossRefStyleHook(HookBase):
 
             self.key_word = key_word
 
-        self.color = color
+        self.color = parse_color(color)  # Use parse_color
         self.bold = bold
 
     def on_iterate(self, word, field):
@@ -55,22 +54,25 @@ class CrossRefStyleHook(HookBase):
         field.Update()
 
 
-def add_cross_ref_style_hook(word: Word, color: int = 16711680, bold=False, key_word: list[str] = None) -> CrossRefStyleHook:
+def add_cross_ref_style_hook(word: Word, color=16711680, bold=False, key_word: list[str] = None) -> CrossRefStyleHook:
     """
     Set font style of the cross-reference.
 
     :param word: ``noterools.word.Word`` object.
     :type word: Word
-    :param color: Set font color. Defaults to ``blue (16711680)``. You can look up the value at `VBA Documentation
-                  <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
-    :type color: int
+    :param color: Set font color. Accepts integer decimal value (e.g., 16711680 for blue), 
+                 RGB string (e.g., "255, 0, 0" for red), or "word_auto" for automatic color.
+                 Defaults to blue (16711680).
+                 You can look up the values at `VBA Documentation
+                 <https://learn.microsoft.com/en-us/office/vba/api/word.wdcolor>`_.
+    :type color: Union[int, str]
     :param bold: If you make font bold. Defaults to False.
     :type bold: bool
-    :param key_word: A key word list. noterools only change the cross-ref's style which contains the key word you specify, for example, ``["Fig.", "Tab."]``.
-                     noterools will change all cross-refs style if ``ket_word == None``.
+    :param key_word: A key word list. noterools only change the cross-ref's style which contains the key word you specify, 
+                     for example, ``["Fig.", "Tab."]``. noterools will change all cross-refs style if ``key_word == None``.
     :type key_word: list
-    :return:
-    :rtype:
+    :return: The hook instance
+    :rtype: CrossRefStyleHook
     """
     if key_word is None:
         logger.warning("Set style for all cross references because `key_word` is None")

--- a/noterools/utils.py
+++ b/noterools/utils.py
@@ -76,4 +76,49 @@ def find_urls(text: str) -> list[tuple[int, int, str]]:
     return urls
 
 
-__all__ = ["logger", "replace_invalid_char", "get_year_list", "find_urls"]
+def parse_color(color_input):
+    """
+    Parse different color input formats and return the Word VBA Decimal color value.
+    
+    Accepts:
+    - Integer decimal value (e.g., 16711680 for blue)
+    - RGB string (e.g., "255, 0, 0" for red)
+    - Named color constant (e.g., "word_auto" for automatic color)
+    
+    :param color_input: Color in various formats
+    :type color_input: Union[int, str, None]
+    :return: Word VBA Decimal color value
+    :rtype: int or None
+    """
+    # If None, return None (keep default behavior)
+    if color_input is None:
+        return None
+        
+    # If already an integer, assume it's already a valid Decimal color value
+    if isinstance(color_input, int):
+        return color_input
+        
+    # If string, check for different formats
+    if isinstance(color_input, str):
+        # Check for named constants
+        if color_input.lower() == "word_auto":
+            return -16777216  # wdColorAutomatic
+            
+        # Check for RGB format (e.g., "255, 0, 0")
+        try:
+            # Split by comma and strip whitespace
+            rgb_values = [int(x.strip()) for x in color_input.split(",")]
+            
+            # If we have 3 values between 0-255, treat as RGB
+            if len(rgb_values) == 3 and all(0 <= x <= 255 for x in rgb_values):
+                r, g, b = rgb_values
+                # Convert to Word Decimal format: B × 2^16 + G × 2^8 + R
+                return (b << 16) + (g << 8) + r
+        except (ValueError, TypeError):
+            pass
+            
+    # If we reach here, the input format is invalid
+    raise ValueError(f"Invalid color format: {color_input}. Use an integer Decimal value, RGB string (e.g., '255, 0, 0'), or 'word_auto'.")
+
+
+__all__ = ["logger", "replace_invalid_char", "get_year_list", "find_urls", "parse_color"]


### PR DESCRIPTION
## 问题描述

当前在非数字引用格式（如 Author-Date 格式）中，只有年份部分会被添加超链接，而作者部分不会。例如在引用 "Park _et al._, 2016" 中，只有 "2016" 是可点击的，而 "Park _et al._, " 部分不可点击。

有些用户可能希望整个引用（作者和年份）都能被超链接，以提高可用性。

## 改动内容

1. 为 `CitationHyperlinkHook` 类添加了 `full_citation_hyperlink` 参数（默认为 `False`）
2. 当 `full_citation_hyperlink=True` 时，整个引用文本（作者+年份）都会被添加超链接
3. 当 `full_citation_hyperlink=False` 时（默认），保持现有行为，只有年份部分有超链接
4. 这个参数已同步添加到 `add_citation_hyperlink_hook` 和 `add_citation_cross_ref_hook` 函数接口中
5. 修复了括号颜色处理问题，确保左右括号保持黑色（或文档默认颜色）
6. 增强了对分号分隔的多引用情况的处理能力

**技术说明**: 新版本显著改进了对复杂引用的支持。通过更精确的文本位置计算和引用匹配算法，现在能够正确处理多种引用情况：
- 单引用情况（如 "Author, 2020"）
- 分号分隔的多引用（如 "A, 2010; B, 2020; C, 2022"）
- 复杂作者名称情况（如 "Zhan, Lei and Zhang, 2022"）

引用现在都能根据设置决定是否为整个引用添加超链接。

## 影响范围

- 默认行为保持不变，所以这是一个完全向后兼容的增强功能
- 数字式引用格式（如 [1], [1-3]）不受影响
- 仅当用户明确设置 `full_citation_hyperlink=True` 时才会应用新行为

## 使用示例

```python
# 仅年份部分添加超链接（原有默认行为）
add_citation_cross_ref_hook(word, is_numbered=False)

# 整个引用（作者和年份）都添加超链接
add_citation_cross_ref_hook(word, is_numbered=False, full_citation_hyperlink=True)
```

目前已在使用 Cite Them Right 12th edition-Harvard (no "et al.") CSL 的情况下测试，暂未发现问题

## Description of the problem

Currently in non-numeric citation formats (e.g. Author-Date format), only the year part is hyperlinked, but not the author part. For example in the citation "Park _et al._, 2016" only the "2016" is clickable and the "Park _et al._, " section is not.

Some users may want the entire citation (author and year) to be hyperlinked to improve usability.

## Change content

1. added `full_citation_hyperlink` parameter to `CitationHyperlinkHook` class (default is `False`)
2. when `full_citation_hyperlink=True`, the entire citation text (author+year) will be hyperlinked
3. when `full_citation_hyperlink=False` (default), the existing behaviour is maintained and only the year is hyperlinked
4. this parameter has been added to the `add_citation_hyperlink_hook` and `add_citation_cross_ref_hook` function interfaces simultaneously
5. fixed the bracket colour handling issue to ensure that left and right brackets remain black (or the document default colour)
6. improved handling of semicolon-separated multiple references

**Technical Note**: The new version significantly improves support for complex references. Multiple citation cases are now handled correctly through more accurate text position calculations and citation matching algorithms:
- Single citation cases (e.g. "Author, 2020")
- Semicolon-separated multiple citations (e.g. "A, 2010; B, 2020; C, 2022")
- complex author names (e.g. "Zhan, Lei and Zhang, 2022")

In-text citation sections now have the ability to decide whether or not to hyperlink the entire citation based on the settings.

## Scope of impact

- The default behaviour remains unchanged, so this is a fully backwards compatible enhancement!
- Numeric citation formats (e.g. [1], [1-3]) are not affected.
- The new behaviour will only be applied if the user explicitly sets `full_citation_hyperlink=True`

## Usage examples

```python.
## Add hyperlinks for year sections only (original default behaviour)
add_citation_cross_ref_hook(word, is_numbered=False)

# Add hyperlinks to the entire citation (author and year)
add_citation_cross_ref_hook(word, is_numbered=False, full_citation_hyperlink=True)
```

Currently tested with Cite Them Right 12th edition-Harvard (no "et al.") CSL, no problems found yet